### PR TITLE
return sorted list instead of overwriting the tree

### DIFF
--- a/python/lib/binary_tree.py
+++ b/python/lib/binary_tree.py
@@ -325,10 +325,10 @@ class BT:
         """
         Performs a heapfort on the elements of the binary tree in either ascending or descending order
         :param order: decides the sorting order, acceptable values are 'ascending' or 'descending'
-        :return None
+        :return Sorted list of tree elements
         """
         if order == 'ascending':
             sorted = heap_sort.heap_sort_asc(self.elements)
         elif order == 'descending':
             sorted = heap_sort.heap_sort_desc(self.elements)
-        self.root = sorted
+        return sorted

--- a/python/tests/test_bt_algorithms.py
+++ b/python/tests/test_bt_algorithms.py
@@ -42,10 +42,8 @@ class TestWraps:
 
         def test_max_heap_sort_wrap(self):
             x = BT([1,14,4,3,16,8,7,2,10,9])
-            x.heap_sort()
-            assert [1, 2, 3, 4, 7, 8, 9, 10, 14, 16] == x.elements, "The order of elements comprising the tree after ascending heap sort do not match"
+            assert [1, 2, 3, 4, 7, 8, 9, 10, 14, 16] == x.heap_sort(), "The order of elements comprising the tree after ascending heap sort do not match"
 
         def test_min_heap_sort_wrap(self):
             x = BT([1,14,4,3,16,8,7,2,10,9])
-            x.heap_sort(order='descending')
-            assert [16, 14, 10, 9, 8, 7, 4, 3, 2, 1] == x.elements, "The order of elements comprising the tree after descending heap sort do not match"
+            assert [16, 14, 10, 9, 8, 7, 4, 3, 2, 1] == x.heap_sort(order='descending'), "The order of elements comprising the tree after descending heap sort do not match"


### PR DESCRIPTION
Changing the tree elements using heap-sort doesn't make sense
